### PR TITLE
[Fix] Correctly implement PartialEq for StorageMode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aleo-std"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aleo-std-cpu",
  "aleo-std-profiler",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-storage"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dirs",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-std"
-version = "1.0.0"
+version = "1.0.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A standard library for Aleo repositories"
 exclude = ["**/*.md"]
@@ -13,7 +13,7 @@ members = [ "cpu", "profiler", "storage", "time", "timed", "timer" ]
 [dependencies]
 aleo-std-cpu = { path = "./cpu", version = "1.0.0", default-features = false, optional = true }
 aleo-std-profiler = { path = "./profiler", version = "1.0.0", default-features = false }
-aleo-std-storage = { path = "./storage", version = "1.0.0", default-features = false, optional = true }
+aleo-std-storage = { path = "./storage", version = "1.0.1", default-features = false, optional = true }
 aleo-std-time = { path = "./time", version = "1.0.0", default-features = false }
 aleo-std-timed = { path = "./timed", version = "1.0.0", default-features = false }
 aleo-std-timer = { path = "./timer", version = "1.0.0", default-features = false }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleo-std-storage"
-version = "1.0.0"
+version = "1.0.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Convenience methods for accessing resources in Aleo storage"
 license = "GPL-3.0"

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -47,10 +47,11 @@ impl StorageMode {
 impl PartialEq for StorageMode {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Test(Some(tempdir1)), Self::Test(Some(tempdir2))) => {
-                tempdir1.path() == tempdir2.path()
-            },
-            (a, b) => a == b,
+            (StorageMode::Production, StorageMode::Production) => true,
+            (StorageMode::Development(id1), StorageMode::Development(id2)) => id1 == id2,
+            (StorageMode::Custom(path1), StorageMode::Custom(path2)) => path1 == path2,
+            (StorageMode::Test(Some(temp1)), StorageMode::Test(Some(temp2))) => temp1.path() == temp2.path(),
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
https://github.com/ProvableHQ/aleo-std/pull/12 introduced a bug that would cause comparisons between non-`Test` storage instances to loop indefinitely. This PR fixes it.