### PR TITLE
[Release] 1.0.1

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,7 @@
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
 
 # Stable configurations
-edition = "2018"
+edition = "2021"
 max_width = 120
 merge_derives = true
 use_field_init_shorthand = true
@@ -9,8 +9,7 @@ use_try_shorthand = true
 
 # Nightly configurations
 imports_layout = "HorizontalVertical"
-license_template_path = ".resources/license_header"
 imports_granularity = "Crate"
 overflow_delimited_expr = true
 reorder_impl_items = true
-version = "Two"
+style_edition = "2024"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "aleo-std-timed",
  "aleo-std-timer",
  "rusty-hook",
+ "walkdir",
 ]
 
 [[package]]
@@ -291,6 +292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +398,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +437,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,11 +17,11 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-cpu"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "aleo-std-profiler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "colored",
 ]
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-time"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-timed"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-timer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "colored",
 ]
@@ -204,9 +204,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libredox"
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "nias"
@@ -232,9 +232,9 @@ checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "proc-macro2"
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
  "bitflags",
  "errno",
@@ -292,22 +292,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -363,7 +363,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ aleo-std-timer = { path = "./timer", version = "1.0.1", default-features = false
 [dev-dependencies.rusty-hook]
 version = "0.11.2"
 
+[build-dependencies.walkdir]
+version = "2"
+
 [features]
 default = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,18 @@ authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A standard library for Aleo repositories"
 exclude = ["**/*.md"]
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = [ "cpu", "profiler", "storage", "time", "timed", "timer" ]
 
 [dependencies]
-aleo-std-cpu = { path = "./cpu", version = "1.0.0", default-features = false, optional = true }
-aleo-std-profiler = { path = "./profiler", version = "1.0.0", default-features = false }
+aleo-std-cpu = { path = "./cpu", version = "1.0.1", default-features = false, optional = true }
+aleo-std-profiler = { path = "./profiler", version = "1.0.1", default-features = false }
 aleo-std-storage = { path = "./storage", version = "1.0.1", default-features = false, optional = true }
-aleo-std-time = { path = "./time", version = "1.0.0", default-features = false }
-aleo-std-timed = { path = "./timed", version = "1.0.0", default-features = false }
-aleo-std-timer = { path = "./timer", version = "1.0.0", default-features = false }
+aleo-std-time = { path = "./time", version = "1.0.1", default-features = false }
+aleo-std-timed = { path = "./timed", version = "1.0.1", default-features = false }
+aleo-std-timer = { path = "./timer", version = "1.0.1", default-features = false }
 
 [dev-dependencies.rusty-hook]
 version = "0.11.2"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 To use this crate to your repository, add the following to your `Cargo.toml`:
 ```toml
 [dependencies.aleo-std]
-version = "1.0.0"
+version = "1.0.1"
 ```
 
 ### CPU

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the aleo-std library.
+
+// The aleo-std library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The aleo-std library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the aleo-std library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{fs::File, io::Read, path::Path};
+
+use walkdir::WalkDir;
+
+// The following license text that should be present at the beginning of every source file.
+const EXPECTED_LICENSE_TEXT: &[u8] = include_bytes!(".resources/license_header");
+
+// The following directories will be excluded from the license scan.
+const DIRS_TO_SKIP: [&str; 5] = [".cargo", ".circleci", ".git", ".github", "target"];
+
+fn check_file_licenses<P: AsRef<Path>>(path: P) {
+    let path = path.as_ref();
+
+    let mut iter = WalkDir::new(path).into_iter();
+    while let Some(entry) = iter.next() {
+        let entry = entry.unwrap();
+        let entry_type = entry.file_type();
+
+        // Skip the specified directories.
+        if entry_type.is_dir() && DIRS_TO_SKIP.contains(&entry.file_name().to_str().unwrap_or("")) {
+            iter.skip_current_dir();
+
+            continue;
+        }
+
+        // Check all files with the ".rs" extension.
+        if entry_type.is_file() && entry.file_name().to_str().unwrap_or("").ends_with(".rs") {
+            let file = File::open(entry.path()).unwrap();
+            let mut contents = Vec::with_capacity(EXPECTED_LICENSE_TEXT.len());
+            file.take(EXPECTED_LICENSE_TEXT.len() as u64)
+                .read_to_end(&mut contents)
+                .unwrap();
+
+            assert!(
+                contents == EXPECTED_LICENSE_TEXT,
+                "The license in \"{}\" is either missing or it doesn't match the expected string!",
+                entry.path().display()
+            );
+        }
+    }
+
+    // Re-run upon any changes to the workspace.
+    println!("cargo:rerun-if-changed=.");
+}
+
+// The build script; it currently only checks the licenses.
+fn main() {
+    // Check licenses in the current folder.
+    check_file_licenses(".");
+}

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aleo-std-cpu"
-version = "1.0.0"
+version = "1.0.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Convenience method for retrieving CPU information"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "aleo-std-profiler"
-version = "1.0.0"
+version = "1.0.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A profiler to measure runtime performance"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies.colored]
 version = "2"

--- a/profiler/src/lib.rs
+++ b/profiler/src/lib.rs
@@ -36,7 +36,7 @@ pub mod inner {
     macro_rules! start_timer {
         ($msg:expr) => {{
             use std::{sync::atomic::Ordering, time::Instant};
-            use $crate::{compute_indent, Colorize, NUM_INDENT, PAD_CHAR};
+            use $crate::{Colorize, NUM_INDENT, PAD_CHAR, compute_indent};
 
             let msg = $msg();
             let start_info = "Start:".yellow().bold();
@@ -59,7 +59,7 @@ pub mod inner {
         }};
         ($time:expr, $msg:expr) => {{
             use std::sync::atomic::Ordering;
-            use $crate::{compute_indent, Colorize, NUM_INDENT, PAD_CHAR};
+            use $crate::{Colorize, NUM_INDENT, PAD_CHAR, compute_indent};
 
             let time = $time.time;
             let final_time = time.elapsed();
@@ -103,7 +103,7 @@ pub mod inner {
     macro_rules! add_to_trace {
         ($title:expr, $msg:expr) => {{
             use std::sync::atomic::Ordering;
-            use $crate::{compute_indent, compute_indent_whitespace, Colorize, NUM_INDENT, PAD_CHAR};
+            use $crate::{Colorize, NUM_INDENT, PAD_CHAR, compute_indent, compute_indent_whitespace};
 
             let start_msg = "StartMsg".yellow().bold();
             let end_msg = "EndMsg".green().bold();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,17 +15,17 @@
 // along with the aleo-std library. If not, see <https://www.gnu.org/licenses/>.
 
 #[cfg(feature = "cpu")]
-pub use aleo_std_cpu::{get_cpu, Cpu};
+pub use aleo_std_cpu::{Cpu, get_cpu};
 pub use aleo_std_profiler::*;
 #[cfg(feature = "storage")]
-pub use aleo_std_storage::{aleo_dir, aleo_ledger_dir, StorageMode};
+pub use aleo_std_storage::{StorageMode, aleo_dir, aleo_ledger_dir};
 
 pub mod prelude {
     #[cfg(feature = "cpu")]
-    pub use aleo_std_cpu::{get_cpu, Cpu};
+    pub use aleo_std_cpu::{Cpu, get_cpu};
     pub use aleo_std_profiler::*;
     #[cfg(feature = "storage")]
-    pub use aleo_std_storage::{aleo_dir, aleo_ledger_dir, StorageMode};
+    pub use aleo_std_storage::{StorageMode, aleo_dir, aleo_ledger_dir};
     pub use aleo_std_time::time;
     pub use aleo_std_timed::timed;
     pub use aleo_std_timer::{finish, lap, timer};

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Convenience methods for accessing resources in Aleo storage"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies.dirs]
 version = "4.0"

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -136,7 +136,7 @@ pub fn aleo_ledger_dir(network: u16, mode: &StorageMode) -> PathBuf {
                 // aleo_ledger_dir is only ever called with persistent storage, where TempDir must be present.
                 panic!("StorageMode::Test was created in a persistent storage context without a TempDir");
             }
-        },
+        }
     }
 }
 

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "aleo-std-time"
-version = "1.0.0"
+version = "1.0.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A convenience attribute to time functions"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/timed/Cargo.toml
+++ b/timed/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "aleo-std-timed"
-version = "1.0.0"
+version = "1.0.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A profiler to conveniently time function executions"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/timer/Cargo.toml
+++ b/timer/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "aleo-std-timer"
-version = "1.0.0"
+version = "1.0.1"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A timer to conveniently time code blocks"
 license = "GPL-3.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies.colored]
 version = "2"


### PR DESCRIPTION
This PR bumps version numbers from 1.0.0 to 1.0.1.

Additional structural changes were made to match snarkVM and snarkOS:
- Add license checks via `build.rs`
- Updated `.rustfmt.toml`
- Updated edition from 2018 to 2021